### PR TITLE
Add delay multiplier

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -20,6 +20,7 @@ commander
     .option("--enable-chrome-network-service", "Enable Chromium's Network Service (needed when login provider redirects with 3XX)")
     .option("--no-verify-ssl", "Disable SSL Peer Verification for connections to AWS (no effect if behind proxy)")
     .option("--enable-chrome-seamless-sso", "Enable Chromium's pass-through authentication with Azure Active Directory Seamless Single Sign-On")
+    .option("--delay", "Introduce a custom delay between page loads (useful for slow connections). Use 1 for standard delay, 2 for double the delay, etc.")
     .parse(process.argv);
 
 const profileName = commander.profile || process.env.AWS_PROFILE || "default";
@@ -29,11 +30,12 @@ const noPrompt = !commander.prompt;
 const enableChromeNetworkService = commander.enableChromeNetworkService;
 const awsNoVerifySsl = !commander.verifySsl;
 const enableChromeSeamlessSso = commander.enableChromeSeamlessSso;
+const customDelayModifier = commander.delay || 1;
 
 Promise.resolve()
     .then(() => {
         if (commander.configure) return configureProfileAsync(profileName);
-        return login.loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso);
+        return login.loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso, customDelayModifier);
     })
     .catch(err => {
         if (err.name === "CLIError") {

--- a/lib/login.js
+++ b/lib/login.js
@@ -30,11 +30,10 @@ const AZURE_AD_SSO = "autologon.microsoftazuread-sso.com";
  * with puppeteer's page.$(selector) to determine if the state is active, and a handler
  * that is called if the state is active.
  */
-const states = [
-    {
+const states = [{
         name: "username input",
         selector: `input[name="loginfmt"]:not(.moveOffScreen)`,
-        async handler(page, _selected, noPrompt, defaultUsername, _defaultPassword) {
+        async handler(page, _selected, noPrompt, defaultUsername, _defaultPassword, customDelayModifier) {
             const error = await page.$(".alert-error");
             if (error) {
                 debug("Found error message. Displaying");
@@ -67,12 +66,12 @@ const states = [
             debug("Typing username");
             await page.keyboard.type(username);
 
-            await Bluebird.delay(500);
+            await Bluebird.delay(500 * customDelayModifier);
 
             debug("Submitting form");
             await page.click("input[type=submit]");
 
-            await Bluebird.delay(500);
+            await Bluebird.delay(500 * customDelayModifier);
 
             debug("Waiting for submission to finish");
             await Promise.race([
@@ -87,7 +86,7 @@ const states = [
     {
         name: "account selection",
         selector: `#aadTile > div > div.table-cell.tile-img > img`,
-        async handler(page) {
+        async handler(page, customDelayModifier) {
             debug("Multiple accounts associated with username.");
             const aadTile = await page.$("#aadTileTitle");
             const aadTileMessage = await page.evaluate(aadTile => aadTile.textContent, aadTile);
@@ -118,13 +117,13 @@ const states = [
 
             debug(`Proceeding with account ${account.selector}`);
             await page.click(account.selector);
-            await Bluebird.delay(500);
+            await Bluebird.delay(500 * customDelayModifier);
         }
     },
     {
         name: "password input",
         selector: `input[name="Password"]:not(.moveOffScreen),input[name="passwd"]:not(.moveOffScreen)`,
-        async handler(page, _selected, noPrompt, _defaultUsername, defaultPassword) {
+        async handler(page, _selected, noPrompt, _defaultUsername, defaultPassword, customDelayModifier) {
             const error = await page.$(".alert-error");
             if (error) {
                 debug("Found error message. Displaying");
@@ -157,7 +156,7 @@ const states = [
             await page.click("span[class=submit],input[type=submit]");
 
             debug("Waiting for a delay");
-            await Bluebird.delay(500);
+            await Bluebird.delay(500 * customDelayModifier);
         }
     },
     {
@@ -182,7 +181,7 @@ const states = [
     {
         name: 'TFA code input',
         selector: "input[name=otc]:not(.moveOffScreen)",
-        async handler(page) {
+        async handler(page, customDelayModifier) {
             const error = await page.$(".alert-error");
             if (error) {
                 debug("Found error message. Displaying");
@@ -216,8 +215,8 @@ const states = [
             debug("Waiting for submission to finish");
             await Promise.race([
                 page.waitForSelector(`input[name=otc].has-error,input[name=otc].moveOffScreen`, { timeout: 60000 }),
-                (async () => {
-                    await Bluebird.delay(1000);
+                (async() => {
+                    await Bluebird.delay(1000 * customDelayModifier);
                     await page.waitForSelector(`input[name=otc]`, { hidden: true, timeout: 60000 });
                 })()
             ]);
@@ -226,12 +225,12 @@ const states = [
     {
         name: "Remember me",
         selector: `#KmsiDescription`,
-        async handler(page) {
+        async handler(page, customDelayModifier) {
             debug("Clicking don't remember button");
             await page.click("#idBtn_Back");
 
             debug("Waiting for a delay");
-            await Bluebird.delay(500);
+            await Bluebird.delay(500 * customDelayModifier);
         }
     },
     {
@@ -245,7 +244,7 @@ const states = [
 ];
 
 module.exports = {
-    async loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso) {
+    async loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso, customDelayModifier) {
         let headless, cliProxy;
         if (mode === 'cli') {
             headless = true;
@@ -262,7 +261,7 @@ module.exports = {
 
         const profile = await this._loadProfileAsync(profileName);
         const loginUrl = await this._createLoginUrlAsync(profile.azure_app_id_uri, profile.azure_tenant_id);
-        const samlResponse = await this._performLoginAsync(loginUrl, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, profile.azure_default_username, profile.azure_default_password, enableChromeSeamlessSso);
+        const samlResponse = await this._performLoginAsync(loginUrl, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, profile.azure_default_username, profile.azure_default_password, enableChromeSeamlessSso, customDelayModifier);
         const roles = this._parseRolesFromSamlResponse(samlResponse);
         const { role, durationHours } = await this._askUserForRoleAndDurationAsync(roles, noPrompt, profile.azure_default_role_arn, profile.azure_default_duration_hours);
         await this._assumeRoleAsync(profileName, samlResponse, role, durationHours, awsNoVerifySsl);
@@ -363,7 +362,7 @@ module.exports = {
      * @returns {Promise.<string>} The SAML response.
      * @private
      */
-    async _performLoginAsync(url, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, defaultUsername, defaultPassword, enableChromeSeamlessSso) {
+    async _performLoginAsync(url, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, defaultUsername, defaultPassword, enableChromeSeamlessSso, customDelayModifier) {
         debug("Loading login page in Chrome");
         let browser;
         try {
@@ -381,7 +380,7 @@ module.exports = {
             });
 
             // Wait for a bit as sometimes the browser isn't ready.
-            await Bluebird.delay(200);
+            await Bluebird.delay(200 * customDelayModifier);
 
             const pages = await browser.pages();
             const page = pages[0];


### PR DESCRIPTION
In some situations, a slow connection will cause `aws-azure-login` to fail because it doesn't wait long enough. Introducing an even longer delay will make the experience unpleasant for users on fast connections. This change introduces a multiplier argument, used as follows:

| Command | Result
| --- | ---
| `aws-azure-login --profile saml` | Standard behaviour, no change to delays
| `aws-azure-login --profile saml --delay 1` | Standard behaviour, all delays multiplied by 1
| `aws-azure-login --profile saml --delay 2` | All delays multiplied by two

FYI @bmatheson1 